### PR TITLE
Remove the dangerous "force" flags for docker system prune to warn users

### DIFF
--- a/platform/cleanup/cleanup.sh
+++ b/platform/cleanup/cleanup.sh
@@ -17,8 +17,8 @@ DIRECTORY="$1"
 # kill all container
 ./cleanup/container_cleanup.sh "${DIRECTORY}"
 
-# remove all container & restart docker
-docker system prune -f
+# WARNING: remove all stopped containers, unused networks, dangling images, unused build cache & restart docker
+docker system prune
 
 echo -n "ovs-vsctl " > ovs_command.txt
 

--- a/platform/cleanup/container_cleanup.sh
+++ b/platform/cleanup/container_cleanup.sh
@@ -89,4 +89,5 @@ docker kill MEASUREMENT &>/dev/null || true &
 docker kill MATRIX &>/dev/null || true &
 
 wait
-docker system prune -f
+# WARNING: remove all stopped containers, unused networks, dangling images, unused build cache
+docker system prune

--- a/platform/cleanup/hard_reset.sh
+++ b/platform/cleanup/hard_reset.sh
@@ -8,8 +8,8 @@ for container in `docker ps -q`; do
 done
 wait
 
-# remove all container & restart docker
-docker system prune -f
+# WARNING: remove all stopped containers, unused networks, dangling images, unused build cache & restart docker
+docker system prune
 service docker restart
 
 # remove all ovs-bridges

--- a/platform/startup.sh
+++ b/platform/startup.sh
@@ -5,8 +5,9 @@
 FORCE_REMOVE_ALL=0
 
 if [ $FORCE_REMOVE_ALL == 1 ]; then
-    sudo docker system prune  --all --force
-    sudo docker image prune  --all --force
+    # WARNING: remove all stopped containers, unused networks, dangling images, unused build cache
+    sudo docker system prune  --all
+    sudo docker image prune  --all
 
     echo ""
     echo ""


### PR DESCRIPTION
Hi team, 

Thanks for providing this interesting mini internet project to the open-source community!
However, I did notice that there are several **force deletion actions for docker** in the setup and cleanup scripts (specifically, `docker system prune -f`), which could be hazardous to users' local docker data and configurations.

**I am submitting this pr to remove all the force flags for two purposes: 1) warning users with the deletion details, 2) letting users to choose whether to proceed or not.**

Lastly, I would like to know is there any other way to limit the scope for cleaning up docker resources other than system-wide pruning?

Best regards,
Bruce